### PR TITLE
Add console.info into the matchers for JS

### DIFF
--- a/lib/matchers.rb
+++ b/lib/matchers.rb
@@ -33,7 +33,7 @@ MATCHERS = {
       },
       {
         name: 'console',
-        regex: /^\s*console\.(log|warn|debug|error)/
+        regex: /^\s*console\.(log|warn|debug|error|info)/
       }
     ]
   },


### PR DESCRIPTION
Hi!

Would you agree with this addition? I've added `console.info` into the matchers for JS, as I regularly use this when I'm debugging applications.

Kind Regards,
Matt